### PR TITLE
Use custom slabs for keyPair, discoveryKey and namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,9 +121,13 @@ if (sodium.sodium_free) {
 
 exports.namespace = function (name, count) {
   const ids = typeof count === 'number' ? range(count) : count
-  const buf = b4a.allocUnsafe(32 * ids.length)
+
+  // Namespaces are long-lived, so better to use a dedicated slab
+  const buf = b4a.allocUnsafeSlow(32 * ids.length)
+
   const list = new Array(ids.length)
 
+  // ns is emhemeral, so default slab
   const ns = b4a.allocUnsafe(33)
   sodium.crypto_generichash(ns.subarray(0, 32), typeof name === 'string' ? b4a.from(name) : name)
 

--- a/test.js
+++ b/test.js
@@ -90,6 +90,8 @@ test('namespace', function (t) {
 
   t.alike(ns[0], b4a.from('a931a0155b5c09e6d28628236af83c4b8a6af9af60986edeede9dc5d63192bf7', 'hex'))
   t.alike(ns[1], b4a.from('742c9d833d430af4c48a8705e91631eecf295442bbca18996e597097723b1061', 'hex'))
+  t.is(ns[0].buffer.byteLength < 1000, true, 'no default slab')
+  t.is(ns[0].buffer, ns[1].buffer, 'slab shared between entries')
 })
 
 test('namespace (random access)', function (t) {

--- a/test.js
+++ b/test.js
@@ -14,6 +14,8 @@ test('key pair', function (t) {
 
   t.is(keyPair.publicKey.length, 32)
   t.is(keyPair.secretKey.length, 64)
+  t.is(keyPair.publicKey.buffer.byteLength, 96, 'small slab')
+  t.is(keyPair.publicKey.buffer, keyPair.secretKey.buffer, 'public and seret key share the same slab')
 })
 
 test('validate key pair', function (t) {
@@ -109,4 +111,10 @@ test('random namespace', function (t) {
   const ns2 = crypto.namespace(s, [1, 2, 3, 4, 5, 6, 7, 8, 9])
 
   t.alike(ns1, ns2)
+})
+
+test('discovery key does not use slabs', function (t) {
+  const key = b4a.allocUnsafe(32)
+  const discKey = crypto.discoveryKey(key)
+  t.is(discKey.buffer.byteLength, 32, 'does not use slab memory')
 })


### PR DESCRIPTION
hypercore-crypto uses `b4a.allocUnsafe(...)`, which uses slab memory, with slabs of 8192 bytes by default. In the stack, we often use hypercore-crypto to generate buffers which stay around for a long time. This means that those small buffers (e.g. 32 bytes for a discovery key) retain the full 8192 slab in memory.

This PR proposes to update hypercore-crypto itself to not use the default slab memory, starting with  keyPair and discoveryKey (both quite likely to be used for long-term buffers)

The alternative is to copy out those buffers after generating them, in the modules where hypercore-crypto is used.

