### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "dependencies": {
     "b4a": "^1.6.6",
-    "compact-encoding": "^2.15.0",
+    "compact-encoding": "^3.0.0",
     "sodium-universal": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`hypercore-crypto` doesn't use `buffer` so straight forward dependency bump.